### PR TITLE
CI: only run on changed files

### DIFF
--- a/2023/01/leodev.v
+++ b/2023/01/leodev.v
@@ -1,7 +1,5 @@
 import os { read_file }
 
-// hello
-
 fn main() {
 	inputs_part1 := read_file('trebuchet-part1.input')!.split_into_lines()
 	println(part1(inputs_part1))

--- a/2023/01/leodev.v
+++ b/2023/01/leodev.v
@@ -1,4 +1,5 @@
 import os { read_file }
+// hi
 
 fn main() {
 	inputs_part1 := read_file('trebuchet-part1.input')!.split_into_lines()

--- a/2023/01/leodev.v
+++ b/2023/01/leodev.v
@@ -1,5 +1,7 @@
 import os { read_file }
 
+// hello
+
 fn main() {
 	inputs_part1 := read_file('trebuchet-part1.input')!.split_into_lines()
 	println(part1(inputs_part1))

--- a/2023/01/leodev.v
+++ b/2023/01/leodev.v
@@ -1,5 +1,4 @@
 import os { read_file }
-// hi
 
 fn main() {
 	inputs_part1 := read_file('trebuchet-part1.input')!.split_into_lines()

--- a/verify.v
+++ b/verify.v
@@ -59,7 +59,7 @@ fn discover_files() ![]string {
 	if glob_pattern == '**' {
 		if os.getenv('CI') != '' {
 			// https://stackoverflow.com/a/25071749
-			changes := os.execute('git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD main)').output.split_into_lines()
+			changes := os.execute('git --no-pager diff --name-only $(git merge-base FETCH_HEAD main) FETCH_HEAD').output.split_into_lines()
 			files := changes.filter(it.ends_with('.v') && it.starts_with('20'))
 			if files.len > 0 {
 				eprintln('running only a subset of tests based on the git diff: ${files}')
@@ -102,6 +102,11 @@ fn main() {
 	mut total_running_time := time.Duration(0)
 	for idx, v_file in v_files {
 		os.chdir(wd)!
+		if !os.exists(v_file) {
+			// in the case of a CI diff, the file may have been deleted
+			eprintln('> skipping missing file ${v_file}')
+			continue
+		}
 		vdir := os.dir(v_file)
 		os.chdir(vdir)!
 

--- a/verify.v
+++ b/verify.v
@@ -58,13 +58,12 @@ fn discover_files() ![]string {
 	glob_pattern := '*' + os.args[1] or { '' } + '*'
 	if glob_pattern == '**' {
 		if os.getenv('CI') != '' {
-			// https://stackoverflow.com/a/25071749
-			changes := os.execute('git --no-pager diff --name-only origin').output.split_into_lines()
+			git_diff_cmd := 'git --no-pager diff --name-only origin'
+			println(git_diff_cmd)
+			changes := os.execute(git_diff_cmd).output.split_into_lines()
 			files := changes.filter(it.ends_with('.v') && it.starts_with('20'))
-			if files.len > 0 {
-				eprintln('running only a subset of tests based on the git diff: ${files}')
-				return files
-			}
+			println('running only a subset of all tests, based on the git diff for the new/changed solutions, compared to the main origin branch: ${files}')
+			return files
 		}
 		println('Note: you can also `v run verify.v PATTERN`, where PATTERN can be any part of the .v filepath, like: `v run verify.v 2022` or `v run verify.v Jalon` etc.')
 	}

--- a/verify.v
+++ b/verify.v
@@ -59,8 +59,8 @@ fn discover_files() ![]string {
 	if glob_pattern == '**' {
 		if os.getenv('CI') != '' {
 			// https://stackoverflow.com/a/25071749
-			changes := os.execute('git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD main)')!.split_into_lines()
-			files := changes.filter(it.endswith('.v') && it.startswith('20'))
+			changes := os.execute('git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD main)').output.split_into_lines()
+			files := changes.filter(it.ends_with('.v') && it.starts_with('20'))
 			if files.len > 0 {
 				eprintln('running only a subset of tests based on the git diff: ${files}')
 				return files
@@ -89,7 +89,7 @@ fn discover_files() ![]string {
 }
 
 fn main() {
-	v_files := discover_files()!
+	mut v_files := discover_files()!
 	v_files.sort_with_compare(fn (a &string, b &string) int {
 		xa := a.split('/').map(if it.len == 1 { '0${it}' } else { it }).join('/')
 		xb := b.split('/').map(if it.len == 1 { '0${it}' } else { it }).join('/')

--- a/verify.v
+++ b/verify.v
@@ -57,7 +57,7 @@ fn vout(v_file string, output string) !(string, bool) {
 fn discover_files() ![]string {
 	glob_pattern := '*' + os.args[1] or { '' } + '*'
 	if glob_pattern == '**' {
-		if os.getenv('CI') == 'true' {
+		if os.getenv('CI') != '' {
 			// https://stackoverflow.com/a/25071749
 			changes := os.execute('git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD main)')!.split_into_lines()
 			files := changes.filter(it.endswith('.v') && it.startswith('20'))

--- a/verify.v
+++ b/verify.v
@@ -59,7 +59,7 @@ fn discover_files() ![]string {
 	if glob_pattern == '**' {
 		if os.getenv('CI') != '' {
 			// https://stackoverflow.com/a/25071749
-			changes := os.execute('git --no-pager diff --name-only $(git merge-base FETCH_HEAD main) FETCH_HEAD').output.split_into_lines()
+			changes := os.execute('git --no-pager diff --name-only origin').output.split_into_lines()
 			files := changes.filter(it.ends_with('.v') && it.starts_with('20'))
 			if files.len > 0 {
 				eprintln('running only a subset of tests based on the git diff: ${files}')

--- a/verify.v
+++ b/verify.v
@@ -150,7 +150,7 @@ fn main() {
 		}
 		exit(1)
 	}
-	if new_files.len > 0 && os.getenv('CI') == 'true' {
+	if new_files.len > 0 && os.getenv('CI') != '' {
 		eprintln('Detected ${new_files.len} missing output files, you should run "v run verify.v" to generate output files')
 		for n in new_files {
 			eprintln('    v run verify.v ${n}')

--- a/verify.v
+++ b/verify.v
@@ -60,7 +60,7 @@ fn discover_files() ![]string {
 		if os.getenv('CI') == 'true' {
 			// https://stackoverflow.com/a/25071749
 			changes := os.execute('git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD main)')!.split_into_lines()
-			files := changes.filter(it.endswith('.v'))
+			files := changes.filter(it.endswith('.v') && it.startswith('20'))
 			if files.len > 0 {
 				eprintln('running only a subset of tests based on the git diff: ${files}')
 				return files


### PR DESCRIPTION
Currently tests take a bit over 4 minutes to complete because there are a lot of unoptimized tests from a few years ago.

The `git diff` command will only return changed files when the workflow runs on PRs. When ran on master as per CRON schedule, it should run all tests as normal.

This is untested.